### PR TITLE
app-store-connect-api@v4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rage-against-the-pixel/app-store-connect-api",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rage-against-the-pixel/app-store-connect-api",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "jose": "5.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rage-against-the-pixel/app-store-connect-api",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "A TypeScript package for communicating with Apple App Store Connect API",
   "author": "RageAgainstThePixel",
   "license": "MIT",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import * as services from './app_store_connect_api/sdk.gen';
+import * as api from './app_store_connect_api/sdk.gen';
 import { client } from './app_store_connect_api/client.gen';
 import * as jose from 'jose';
 import fs from 'fs';
@@ -38,7 +38,7 @@ export class AppStoreConnectClient {
   private appStoreConnectOptions: AppStoreConnectOptions;
   private bearerToken: string | null = null;
   private bearerTokenGeneratedAt = 0;
-  api = services;
+  public readonly api = api;
 
   constructor(appStoreConnectOptions: AppStoreConnectOptions) {
     if (!appStoreConnectOptions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './client';
+export * from './app_store_connect_api';


### PR DESCRIPTION
- hotfix for exporting all app_store_connect_api types under index